### PR TITLE
Introduce `cgp-run` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cgp-run-sync"
+version = "0.1.0"
+dependencies = [
+ "cgp-component-sync",
+ "cgp-error-sync",
+ "cgp-sync",
+]
+
+[[package]]
 name = "cgp-strip-async"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cgp-run"
+version = "0.1.0"
+dependencies = [
+ "cgp-async",
+ "cgp-component",
+ "cgp-error",
+]
+
+[[package]]
 name = "cgp-strip-async"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,7 @@ dependencies = [
  "cgp-async",
  "cgp-component",
  "cgp-error",
+ "cgp-run",
 ]
 
 [[package]]
@@ -60,6 +61,7 @@ version = "0.1.0"
 dependencies = [
  "cgp-component-sync",
  "cgp-error-sync",
+ "cgp-run-sync",
  "cgp-sync",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ members = [
     "crates/cgp-core",
     "crates/cgp-core-sync",
     "crates/cgp-run",
+    "crates/cgp-run-sync",
 ]
 
 
 [patch.crates-io]
+cgp-strip-async     = { path = "./crates/cgp-strip-async" }
 cgp-core            = { path = "./crates/cgp-core" }
 cgp-core-sync       = { path = "./crates/cgp-core-sync" }
 cgp-async           = { path = "./crates/cgp-async" }
@@ -26,4 +28,5 @@ cgp-component-sync  = { path = "./crates/cgp-component-sync" }
 cgp-component-macro = { path = "./crates/cgp-component-macro" }
 cgp-error           = { path = "./crates/cgp-error" }
 cgp-error-sync      = { path = "./crates/cgp-error-sync" }
-cgp-strip-async     = { path = "./crates/cgp-strip-async" }
+cgp-run             = { path = "./crates/cgp-run" }
+cgp-run-sync        = { path = "./crates/cgp-run-sync" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/cgp-strip-async",
     "crates/cgp-core",
     "crates/cgp-core-sync",
+    "crates/cgp-run",
 ]
 
 

--- a/crates/cgp-component-macro/src/helper/consumer_impl.rs
+++ b/crates/cgp-component-macro/src/helper/consumer_impl.rs
@@ -37,7 +37,7 @@ pub fn derive_consumer_impl(
 
         {
             let has_component_constraint: Punctuated<TypeParamBound, Plus> = parse_quote! {
-                cgp_core::HasComponents
+                HasComponents
             };
 
             let provider_constraint: Punctuated<TypeParamBound, Plus> = parse_quote! {

--- a/crates/cgp-component-macro/src/helper/provider_impl.rs
+++ b/crates/cgp-component-macro/src/helper/provider_impl.rs
@@ -23,7 +23,7 @@ pub fn derive_provider_impl(
 
         {
             let delegate_constraint: Punctuated<TypeParamBound, Plus> = parse_quote! {
-                cgp_core::DelegateComponent< #component_name < #component_params > >
+                DelegateComponent< #component_name < #component_params > >
             };
 
             let mut provider_generics = provider_trait.generics.clone();

--- a/crates/cgp-component-macro/src/helper/provider_trait.rs
+++ b/crates/cgp-component-macro/src/helper/provider_trait.rs
@@ -27,7 +27,7 @@ pub fn derive_provider_trait(
         let context_constraints =
             iter_parse_and_replace_self_type(provider_trait.supertraits.clone(), context_type)?;
 
-        provider_trait.supertraits = parse_quote!(cgp_core::Async);
+        provider_trait.supertraits = parse_quote!(Async);
 
         if !context_constraints.is_empty() {
             if let Some(where_clause) = &mut provider_trait.generics.where_clause {

--- a/crates/cgp-core-sync/Cargo.toml
+++ b/crates/cgp-core-sync/Cargo.toml
@@ -19,3 +19,4 @@ all-features = true
 cgp-async       = { version = "0.1.0", package = "cgp-sync" }
 cgp-component   = { version = "0.1.0", package = "cgp-component-sync" }
 cgp-error       = { version = "0.1.0", package = "cgp-error-sync" }
+cgp-run         = { version = "0.1.0", package = "cgp-run-sync" }

--- a/crates/cgp-core/Cargo.toml
+++ b/crates/cgp-core/Cargo.toml
@@ -19,3 +19,4 @@ all-features = true
 cgp-async       = { version = "0.1.0" }
 cgp-component   = { version = "0.1.0" }
 cgp-error       = { version = "0.1.0" }
+cgp-run         = { version = "0.1.0" }

--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+pub mod prelude;
+
 pub use cgp_component::{
     delegate_component, delegate_components, derive_component, DelegateComponent, HasComponents,
 };
@@ -7,3 +9,5 @@ pub use cgp_component::{
 pub use cgp_async::{async_trait, Async};
 
 pub use cgp_error::{CanRaiseError, HasErrorType};
+
+pub use cgp_run::{CanRun, Runner, RunnerComponent};

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,0 +1,3 @@
+pub use cgp_component::{derive_component, DelegateComponent, HasComponents};
+
+pub use cgp_async::{async_trait, Async};

--- a/crates/cgp-run-sync/Cargo.toml
+++ b/crates/cgp-run-sync/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name         = "cgp-run-sync"
+version      = "0.1.0"
+edition      = "2021"
+license      = "Apache-2.0"
+readme       = "README.md"
+keywords     = ["context-generic programming"]
+repository   = "https://github.com/informalsystems/cgp"
+authors      = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+rust-version = "1.72"
+description  = """
+    Context-generic programming core traits
+"""
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+cgp-async = { version = "0.1.0", package = "cgp-sync" }
+cgp-error = { version = "0.1.0", package = "cgp-error-sync" }
+cgp-component = { version = "0.1.0", package = "cgp-component-sync" }

--- a/crates/cgp-run-sync/src
+++ b/crates/cgp-run-sync/src
@@ -1,0 +1,1 @@
+../cgp-run/src

--- a/crates/cgp-run/Cargo.toml
+++ b/crates/cgp-run/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name         = "cgp-run"
+version      = "0.1.0"
+edition      = "2021"
+license      = "Apache-2.0"
+readme       = "README.md"
+keywords     = ["context-generic programming"]
+repository   = "https://github.com/informalsystems/cgp"
+authors      = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+rust-version = "1.72"
+description  = """
+    Context-generic programming core traits
+"""
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+cgp-async = { version = "0.1.0" }
+cgp-error = { version = "0.1.0" }
+cgp-component = { version = "0.1.0" }

--- a/crates/cgp-run/src/lib.rs
+++ b/crates/cgp-run/src/lib.rs
@@ -2,7 +2,9 @@
 
 extern crate alloc;
 
+#[allow(unused_imports)]
 use alloc::boxed::Box;
+
 use cgp_async::{async_trait, Async};
 use cgp_component::{derive_component, DelegateComponent, HasComponents};
 use cgp_error::HasErrorType;

--- a/crates/cgp-run/src/lib.rs
+++ b/crates/cgp-run/src/lib.rs
@@ -9,7 +9,7 @@ use cgp_async::{async_trait, Async};
 use cgp_component::{derive_component, DelegateComponent, HasComponents};
 use cgp_error::HasErrorType;
 
-#[derive_component(RunnerComponent, Runner<App>)]
+#[derive_component(RunnerComponent, Runner<Context>)]
 #[async_trait]
 pub trait CanRun: HasErrorType {
     async fn run(&self) -> Result<(), Self::Error>;

--- a/crates/cgp-run/src/lib.rs
+++ b/crates/cgp-run/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use cgp_async::{async_trait, Async};
+use cgp_component::{derive_component, DelegateComponent, HasComponents};
+use cgp_error::HasErrorType;
+
+#[derive_component(RunnerComponent, Runner<App>)]
+#[async_trait]
+pub trait CanRun: HasErrorType {
+    async fn run(&self) -> Result<(), Self::Error>;
+}


### PR DESCRIPTION
- The `cgp-run` crate provides a `CanRun` / `Runner<Context>`.
- Simplify `cgp-component-macro` to require `HasComponents` and `DelegateComponent` to be explicitly imported.
- Add runner component to `cgp-core`.
- Introduce `cgp_core::prelude` module to import common constructs for defining components.