### PR TITLE
Redesign syntax for `delegate_components!` macro

### DIFF
--- a/crates/cgp-component/src/macros/delegate_component.rs
+++ b/crates/cgp-component/src/macros/delegate_component.rs
@@ -1,8 +1,10 @@
 #[macro_export]
 macro_rules! delegate_component {
-    ( $key:ty, $target:ident $( < $( $param:ident ),* $(,)? > )?, $forwarded:ty $(,)?  ) => {
+    ( $target:ident $( < $( $param:ident ),* $(,)? > )?;
+        $name:ty : $forwarded:ty $(,)?
+    ) => {
         impl< $( $( $param ),* )* >
-            $crate::traits::delegate_component::DelegateComponent<$key>
+            $crate::traits::delegate_component::DelegateComponent< $name >
             for $target $( < $( $param ),* > )*
         where
             Self: $crate::traits::sync::Async,

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -1,10 +1,44 @@
 #[macro_export]
 macro_rules! delegate_components {
-    ( [$(,)?], $target:ident $( < $( $param:ident ),* $(,)? > )?, $forwarded:ty $(,)? ) => {
+    ( $target:ident $( < $( $param:ident ),* $(,)? > )? ; ) => {
 
     };
-    ( [$name:ty $(, $($rest:tt)* )?], $target:ident $( < $( $param:ident ),* $(,)? > )?, $forwarded:ty $(,)?  ) => {
-        $crate::delegate_component!($name, $target $( < $( $param ),* > )*, $forwarded);
-        $crate::delegate_components!([ $( $($rest)* )? ], $target $( < $( $param ),* > )*, $forwarded);
+    (   $target:ident $( < $( $param:ident ),* $(,)? > )?;
+        [ ] : $forwarded:ty
+        $( , $( $rest:tt )* )?
+    ) => {
+        $crate::delegate_components!(
+            $target $( < $( $param ),* > )* ;
+            $( $( $rest )*  )?
+        );
+    };
+    ( $target:ident $( < $( $param:ident ),* $(,)? > )? ;
+        [ $name:ty $(, $($names:tt)* )?] : $forwarded:ty
+        $( , $( $rest:tt )* )?
+    ) => {
+        $crate::delegate_component!(
+            $target $( < $( $param ),* > )*;
+            $name : $forwarded
+        );
+
+        $crate::delegate_components!(
+            $target $( < $( $param ),* > )* ;
+            [ $( $( $names )* )? ] : $forwarded
+            $( , $( $rest )*  )?
+        );
+    };
+    (   $target:ident $( < $( $param:ident ),* $(,)? > )? ;
+        $name:ty : $forwarded:ty
+        $( , $( $rest:tt )* )?
+    ) => {
+        $crate::delegate_component!(
+            $target $( < $( $param ),* > )*;
+            $name : $forwarded
+        );
+
+        $crate::delegate_components!(
+            $target $( < $( $param ),* > )* ;
+            $( $( $rest )*  )?
+        );
     };
 }

--- a/crates/cgp-component/src/traits/mod.rs
+++ b/crates/cgp-component/src/traits/mod.rs
@@ -1,6 +1,6 @@
 pub mod delegate_component;
 pub mod has_components;
+pub mod sync;
 
 pub use delegate_component::DelegateComponent;
 pub use has_components::HasComponents;
-pub mod sync;

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,6 +1,4 @@
-pub use cgp_component::{
-    delegate_component, delegate_components, derive_component, DelegateComponent, HasComponents,
-};
+pub use cgp_component::{delegate_components, derive_component, DelegateComponent, HasComponents};
 
 pub use cgp_async::{async_trait, Async};
 

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,4 +1,6 @@
-pub use cgp_component::{derive_component, DelegateComponent, HasComponents};
+pub use cgp_component::{
+    delegate_component, delegate_components, derive_component, DelegateComponent, HasComponents,
+};
 
 pub use cgp_async::{async_trait, Async};
 


### PR DESCRIPTION
Original syntax:

```rust
delegate_component!(
  ComponentName1,
  TargetComponent,
  SourceComponent1,
);

delegate_components!(
  [
    ComponentName2,
    ComponentName3,
  ],
  TargetComponent,
  SourceComponent2,
);
```

New syntax:

```rust
delegate_components!(
  TargetComponent;
  ComponentName1: SourceComponent1,
  [
    ComponentName2,
    ComponentName3,
  ]: 
    SourceComponent2,
);
```

Also exports `delegate_components!` to `cgp::prelude`