### PR TITLE
Allow delegation of associated types in `derive_component!` macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
 name = "cgp-component-macro"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -111,6 +112,21 @@ name = "cgp-sync"
 version = "0.1.0"
 dependencies = [
  "cgp-strip-async",
+]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/crates/cgp-component-macro/Cargo.toml
+++ b/crates/cgp-component-macro/Cargo.toml
@@ -22,3 +22,4 @@ proc-macro = true
 syn = { version = "2.0.37", features = [ "full" ] }
 quote = "1.0.33"
 proc-macro2 = "1.0.67"
+itertools = "0.11.0"

--- a/crates/cgp-component-macro/src/helper/consumer_impl.rs
+++ b/crates/cgp-component-macro/src/helper/consumer_impl.rs
@@ -72,7 +72,7 @@ pub fn derive_consumer_impl(
         impl_generics
     };
 
-    let mut impl_fns: Vec<ImplItem> = Vec::new();
+    let mut impl_items: Vec<ImplItem> = Vec::new();
 
     for trait_item in consumer_trait.items.iter() {
         match trait_item {
@@ -82,7 +82,7 @@ pub fn derive_consumer_impl(
                     &parse_quote!(#context_type :: Components),
                 );
 
-                impl_fns.push(ImplItem::Fn(impl_fn));
+                impl_items.push(ImplItem::Fn(impl_fn));
             }
             TraitItem::Type(trait_type) => {
                 let type_name = &trait_type.ident;
@@ -92,12 +92,14 @@ pub fn derive_consumer_impl(
                     type_generics
                 };
 
-                derive_delegate_type_impl(
+                let impl_type = derive_delegate_type_impl(
                     &trait_type,
                     parse_quote!(
                         < #context_type :: Components as #provider_name #provider_generics > :: #type_name #type_generics
                     ),
                 );
+
+                impl_items.push(ImplItem::Type(impl_type));
             }
             _ => {}
         }
@@ -119,6 +121,6 @@ pub fn derive_consumer_impl(
         trait_: Some((None, trait_path, For::default())),
         self_ty: Box::new(parse_quote!(#context_type)),
         brace_token: Brace::default(),
-        items: impl_fns,
+        items: impl_items,
     }
 }

--- a/crates/cgp-component-macro/src/helper/delegate_type.rs
+++ b/crates/cgp-component-macro/src/helper/delegate_type.rs
@@ -1,0 +1,16 @@
+use syn::token::Eq;
+use syn::{ImplItemType, TraitItemType, Type, Visibility};
+
+pub fn derive_delegate_type_impl(trait_type: &TraitItemType, delegated_type: Type) -> ImplItemType {
+    ImplItemType {
+        attrs: trait_type.attrs.clone(),
+        vis: Visibility::Inherited,
+        defaultness: None,
+        type_token: trait_type.type_token.clone(),
+        ident: trait_type.ident.clone(),
+        generics: trait_type.generics.clone(),
+        eq_token: Eq::default(),
+        ty: delegated_type,
+        semi_token: trait_type.semi_token.clone(),
+    }
+}

--- a/crates/cgp-component-macro/src/helper/mod.rs
+++ b/crates/cgp-component-macro/src/helper/mod.rs
@@ -2,6 +2,7 @@ pub mod component_name;
 pub mod component_spec;
 pub mod consumer_impl;
 pub mod delegate_fn;
+pub mod delegate_type;
 pub mod derive;
 pub mod provider_impl;
 pub mod provider_trait;

--- a/crates/cgp-component-macro/src/helper/provider_impl.rs
+++ b/crates/cgp-component-macro/src/helper/provider_impl.rs
@@ -57,7 +57,7 @@ pub fn derive_provider_impl(
         impl_generics
     };
 
-    let mut impl_fns: Vec<ImplItem> = Vec::new();
+    let mut impl_items: Vec<ImplItem> = Vec::new();
 
     for trait_item in provider_trait.items.iter() {
         match trait_item {
@@ -67,7 +67,7 @@ pub fn derive_provider_impl(
                     &parse_quote!(#component_type :: Delegate),
                 );
 
-                impl_fns.push(ImplItem::Fn(impl_fn))
+                impl_items.push(ImplItem::Fn(impl_fn))
             }
             TraitItem::Type(trait_type) => {
                 let type_name = &trait_type.ident;
@@ -77,12 +77,14 @@ pub fn derive_provider_impl(
                     type_generics
                 };
 
-                derive_delegate_type_impl(
+                let impl_type = derive_delegate_type_impl(
                     &trait_type,
                     parse_quote!(
                         < #component_type :: Delegate as #provider_name #provider_generics > :: #type_name #type_generics
                     ),
                 );
+
+                impl_items.push(ImplItem::Type(impl_type));
             }
             _ => {}
         }
@@ -104,6 +106,6 @@ pub fn derive_provider_impl(
         trait_: Some((None, trait_path, For::default())),
         self_ty: Box::new(parse_quote!(#component_type)),
         brace_token: Brace::default(),
-        items: impl_fns,
+        items: impl_items,
     }
 }

--- a/crates/cgp-component-macro/src/helper/replace_self_type.rs
+++ b/crates/cgp-component-macro/src/helper/replace_self_type.rs
@@ -1,46 +1,89 @@
+use itertools::Itertools;
 use proc_macro2::{Group, Ident, TokenStream, TokenTree};
 use quote::{format_ident, ToTokens};
 use syn::parse::Parse;
 
-pub fn iter_parse_and_replace_self_type<I, T>(vals: I, replaced_ident: &Ident) -> syn::Result<I>
+pub fn iter_parse_and_replace_self_type<I, T>(
+    vals: I,
+    replaced_ident: &Ident,
+    local_assoc_types: &Vec<Ident>,
+) -> syn::Result<I>
 where
     I: IntoIterator<Item = T> + FromIterator<T>,
     T: ToTokens + Parse,
 {
     vals.into_iter()
-        .map(|val| parse_and_replace_self_type(&val, replaced_ident))
+        .map(|val| parse_and_replace_self_type(&val, replaced_ident, local_assoc_types))
         .collect()
 }
 
-pub fn parse_and_replace_self_type<T>(val: &T, replaced_ident: &Ident) -> syn::Result<T>
+pub fn parse_and_replace_self_type<T>(
+    val: &T,
+    replaced_ident: &Ident,
+    local_assoc_types: &Vec<Ident>,
+) -> syn::Result<T>
 where
     T: ToTokens + Parse,
 {
-    let stream = replace_self_type(val.to_token_stream(), replaced_ident);
+    let stream = replace_self_type(val.to_token_stream(), replaced_ident, local_assoc_types);
     syn::parse2(stream)
 }
 
-pub fn replace_self_type(stream: TokenStream, replaced_ident: &Ident) -> TokenStream {
+pub fn replace_self_type(
+    stream: TokenStream,
+    replaced_ident: &Ident,
+    local_assoc_types: &Vec<Ident>,
+) -> TokenStream {
     let self_type = format_ident!("Self");
 
-    stream
-        .into_iter()
-        .map(|tree| match tree {
+    let mut result_stream: Vec<TokenTree> = Vec::new();
+
+    let mut token_iter = stream.into_iter().multipeek();
+
+    while let Some(tree) = token_iter.next() {
+        match tree {
             TokenTree::Ident(ident) => {
                 if ident == self_type {
-                    TokenTree::Ident(replaced_ident.clone())
+                    let replaced_ident = replaced_ident.clone();
+
+                    // Do not replace self if it is an associated type expression that refers to local associated type
+                    let replaced = match token_iter.peek() {
+                        Some(TokenTree::Punct(p)) if p.as_char() == ':' => {
+                            match token_iter.peek() {
+                                Some(TokenTree::Punct(p)) if p.as_char() == ':' => {
+                                    match token_iter.peek() {
+                                        Some(TokenTree::Ident(assoc_type))
+                                            if local_assoc_types.contains(assoc_type) =>
+                                        {
+                                            ident
+                                        }
+                                        _ => replaced_ident,
+                                    }
+                                }
+                                _ => replaced_ident,
+                            }
+                        }
+                        _ => replaced_ident,
+                    };
+
+                    result_stream.push(TokenTree::Ident(replaced));
                 } else {
-                    TokenTree::Ident(ident)
+                    result_stream.push(TokenTree::Ident(ident));
                 }
             }
             TokenTree::Group(group) => {
-                let replaced_stream = replace_self_type(group.stream(), replaced_ident);
-                let replace_group = Group::new(group.delimiter(), replaced_stream);
+                let replaced_stream =
+                    replace_self_type(group.stream(), replaced_ident, local_assoc_types);
+                let replaced_group = Group::new(group.delimiter(), replaced_stream);
 
-                TokenTree::Group(replace_group)
+                result_stream.push(TokenTree::Group(replaced_group));
             }
-            TokenTree::Punct(punct) => TokenTree::Punct(punct),
-            TokenTree::Literal(lit) => TokenTree::Literal(lit),
-        })
-        .collect()
+            TokenTree::Punct(punct) => {
+                result_stream.push(TokenTree::Punct(punct));
+            }
+            TokenTree::Literal(lit) => result_stream.push(TokenTree::Literal(lit)),
+        }
+    }
+
+    result_stream.into_iter().collect()
 }


### PR DESCRIPTION
We can now include associated types inside the consumer traits that use `derive_component!`.

For example, given the following code:

```rust
#[derive_component(FooRunnerComponent, FooRunner<Context>)]
pub trait CanRunFoo: HasErrorType {
  type Foo;

  fn run_foo(&self, foo: Self::Foo) -> Result<(), Self::Error>;
}
```

Would be expanded into:

```rust
pub struct FooRunnerComponent;

pub trait CanRunFoo: HasErrorType {
  type Foo;

  fn run_foo(&self, foo: Self::Foo) -> Result<(), Self::Error>;
}

pub trait FooRunner<Context>
where
  Context: HasErrorType,
{
  type Foo;
  
  fn run_foo(context: &Context, foo: Self::Foo) -> Result<(), Context::Error>;
}

impl<Context> CanRunFoo for Context
where
  Context: HasErrorType + HasComponents,
  Context::Components: FooRunner<Context>,
{
  type Foo = <Context::Components as FooRunner<Context>>::Foo;

  fn run_foo(&self, foo: Self::Foo) -> Result<(), Self::Error> {
    Context::Components::run_foo(self, foo)
  }
}

impl<Component, Context> FooRunner<Context> for Component
where
  Context: HasErrorType,
  Component: DelegateComponent<FooRunnerComponent>,
  Component::Delegate: FooRunner<Context>,
{
  type Foo = <Component::Delegate as FooRunner<Context>>::Foo;

  fn run_foo(context: &Context, foo: Self::Foo) -> Result<(), Context::Error> {
    Component::Delegate::run_foo(context, foo)
  }
}
```

Notice that inside the macro expansion, the local associated type `Self::Foo` do not get replaced by `Context::Foo`, as the local associated type is tied to the provider trait, not the consumer trait.