### PR TITLE
Introduce `cgp-inner` crate with `HasInner` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cgp-inner"
+version = "0.1.0"
+dependencies = [
+ "cgp-async",
+ "cgp-component",
+]
+
+[[package]]
+name = "cgp-inner-sync"
+version = "0.1.0"
+dependencies = [
+ "cgp-component-sync",
+ "cgp-sync",
+]
+
+[[package]]
 name = "cgp-run"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,9 @@ members = [
     "crates/cgp-core-sync",
     "crates/cgp-run",
     "crates/cgp-run-sync",
+    "crates/cgp-inner",
+    "crates/cgp-inner-sync",
 ]
-
 
 [patch.crates-io]
 cgp-strip-async     = { path = "./crates/cgp-strip-async" }
@@ -30,3 +31,5 @@ cgp-error           = { path = "./crates/cgp-error" }
 cgp-error-sync      = { path = "./crates/cgp-error-sync" }
 cgp-run             = { path = "./crates/cgp-run" }
 cgp-run-sync        = { path = "./crates/cgp-run-sync" }
+cgp-inner           = { path = "./crates/cgp-inner" }
+cgp-inner-sync      = { path = "./crates/cgp-inner-sync" }

--- a/crates/cgp-inner-sync/Cargo.toml
+++ b/crates/cgp-inner-sync/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name         = "cgp-inner-sync"
+version      = "0.1.0"
+edition      = "2021"
+license      = "Apache-2.0"
+readme       = "README.md"
+keywords     = ["context-generic programming"]
+repository   = "https://github.com/informalsystems/cgp"
+authors      = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+rust-version = "1.72"
+description  = """
+    Context-generic programming core traits
+"""
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+cgp-async = { version = "0.1.0", package = "cgp-sync" }
+cgp-component = { version = "0.1.0", package = "cgp-component-sync" }

--- a/crates/cgp-inner-sync/src
+++ b/crates/cgp-inner-sync/src
@@ -1,0 +1,1 @@
+../cgp-inner/src

--- a/crates/cgp-inner/Cargo.toml
+++ b/crates/cgp-inner/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name         = "cgp-inner"
+version      = "0.1.0"
+edition      = "2021"
+license      = "Apache-2.0"
+readme       = "README.md"
+keywords     = ["context-generic programming"]
+repository   = "https://github.com/informalsystems/cgp"
+authors      = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+rust-version = "1.72"
+description  = """
+    Context-generic programming core traits
+"""
+
+[package.metadata.docs.rs]
+all-features = true
+
+[dependencies]
+cgp-async = { version = "0.1.0" }
+cgp-component = { version = "0.1.0" }

--- a/crates/cgp-inner/src/lib.rs
+++ b/crates/cgp-inner/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+extern crate alloc;
+
+use cgp_async::Async;
+use cgp_component::{derive_component, DelegateComponent, HasComponents};
+
+#[derive_component(InnerComponent, ProvideInner<Context>)]
+pub trait HasInner: Async {
+    type Inner: Async;
+
+    fn inner(&self) -> Self::Inner;
+}


### PR DESCRIPTION
The `cgp-inner` crate provides the following trait:

```rust
#[derive_component(InnerComponent, ProvideInner<Context>)]
pub trait HasInner: Async {
    type Inner: Async;

    fn inner(&self) -> Self::Inner;
}
```

The `HasInner` trait allows a `Context` type to extend an `InnerContext` type through composition by implementing `HasInner<Inner = InnerContext>`.