### PR TITLE
Add provider traits to error component traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,22 @@ name = "cgp-error"
 version = "0.1.0"
 dependencies = [
  "cgp-async",
+ "cgp-component",
+]
+
+[[package]]
+name = "cgp-error-eyre"
+version = "0.1.0"
+dependencies = [
+ "cgp-core",
+ "eyre",
+]
+
+[[package]]
+name = "cgp-error-std"
+version = "0.1.0"
+dependencies = [
+ "cgp-core",
 ]
 
 [[package]]
@@ -96,6 +112,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "eyre"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +135,12 @@ checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "crates/cgp-component",
     "crates/cgp-component-macro",
     "crates/cgp-error",
+    "crates/cgp-error-eyre",
+    "crates/cgp-error-std",
     "crates/cgp-strip-async",
     "crates/cgp-core",
     "crates/cgp-run",

--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -8,7 +8,10 @@ pub use cgp_component::{
 
 pub use cgp_async::{async_trait, Async};
 
-pub use cgp_error::{CanRaiseError, HasErrorType};
+pub use cgp_error::{
+    CanRaiseError, ErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent, HasErrorType,
+    ProvideErrorType,
+};
 
 pub use cgp_run::{CanRun, Runner, RunnerComponent};
 

--- a/crates/cgp-error-eyre/Cargo.toml
+++ b/crates/cgp-error-eyre/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name         = "cgp-error-eyre"
+version      = "0.1.0"
+edition      = "2021"
+license      = "Apache-2.0"
+readme       = "README.md"
+keywords     = ["context-generic programming"]
+repository   = "https://github.com/informalsystems/cgp"
+authors      = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+rust-version = "1.72"
+description  = """
+    Context-generic programming core traits
+"""
+
+[dependencies]
+cgp-core    = { version = "0.1.0" }
+eyre        = { version = "0.6.11" }

--- a/crates/cgp-error-eyre/src/lib.rs
+++ b/crates/cgp-error-eyre/src/lib.rs
@@ -1,0 +1,24 @@
+use cgp_core::prelude::*;
+use cgp_core::ErrorRaiser;
+use cgp_core::ProvideErrorType;
+use eyre::Report;
+use std::error::Error as StdError;
+
+pub struct HandleErrorsWithEyre;
+
+impl<Context> ProvideErrorType<Context> for HandleErrorsWithEyre
+where
+    Context: Async,
+{
+    type Error = Report;
+}
+
+impl<Context, E> ErrorRaiser<Context, E> for HandleErrorsWithEyre
+where
+    Context: HasErrorType<Error = Report>,
+    E: StdError + Async,
+{
+    fn raise_error(e: E) -> Report {
+        e.into()
+    }
+}

--- a/crates/cgp-error-std/Cargo.toml
+++ b/crates/cgp-error-std/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name         = "cgp-error-std"
+version      = "0.1.0"
+edition      = "2021"
+license      = "Apache-2.0"
+readme       = "README.md"
+keywords     = ["context-generic programming"]
+repository   = "https://github.com/informalsystems/cgp"
+authors      = ["Informal Systems <hello@informal.systems>", "Soares Chen <soares.chen@maybevoid.com>"]
+rust-version = "1.72"
+description  = """
+    Context-generic programming core traits
+"""
+
+[dependencies]
+cgp-core    = { version = "0.1.0" }

--- a/crates/cgp-error-std/src/lib.rs
+++ b/crates/cgp-error-std/src/lib.rs
@@ -1,0 +1,25 @@
+use cgp_core::prelude::*;
+use cgp_core::ErrorRaiser;
+use cgp_core::ProvideErrorType;
+use std::error::Error as StdError;
+
+pub type Error = Box<dyn StdError + Send + Sync + 'static>;
+
+pub struct HandleErrorsWithStdError;
+
+impl<Context> ProvideErrorType<Context> for HandleErrorsWithStdError
+where
+    Context: Async,
+{
+    type Error = Error;
+}
+
+impl<Context, E> ErrorRaiser<Context, E> for HandleErrorsWithStdError
+where
+    Context: HasErrorType<Error = Error>,
+    E: StdError + Send + Sync + 'static,
+{
+    fn raise_error(e: E) -> Error {
+        e.into()
+    }
+}

--- a/crates/cgp-error/Cargo.toml
+++ b/crates/cgp-error/Cargo.toml
@@ -12,8 +12,6 @@ description  = """
     Context-generic programming core traits
 """
 
-[package.metadata.docs.rs]
-all-features = true
-
 [dependencies]
-cgp-async = { version = "0.1.0" }
+cgp-async       = { version = "0.1.0" }
+cgp-component   = { version = "0.1.0" }

--- a/crates/cgp-error/src/lib.rs
+++ b/crates/cgp-error/src/lib.rs
@@ -1,6 +1,7 @@
 use core::fmt::Debug;
 
 use cgp_async::Async;
+use cgp_component::{derive_component, DelegateComponent, HasComponents};
 
 /**
    This is used for contexts to declare that they have a _unique_ `Self::Error` type.
@@ -13,6 +14,7 @@ use cgp_async::Async;
    parent traits, so that multiple traits can all refer to the same abstract
    `Self::Error` type.
 */
+#[derive_component(ErrorTypeComponent, ProvideErrorType<Context>)]
 pub trait HasErrorType: Async {
     /**
        The `Error` associated type is also required to implement [`Debug`].
@@ -31,6 +33,7 @@ pub trait HasErrorType: Async {
    [`err: ParseIntError`](core::num::ParseIntError) and get back
    a [`Context::Error`](HasErrorType::Error) value.
 */
+#[derive_component(ErrorRaiserComponent, ErrorRaiser<Context>)]
 pub trait CanRaiseError<E>: HasErrorType {
-    fn raise_error(err: E) -> Self::Error;
+    fn raise_error(e: E) -> Self::Error;
 }


### PR DESCRIPTION
- Add `ErrorTypeProvider<Context>` as the provider trait for `HasErrorType`.
- Add `ErrorRaiser<Context, E>` as the provider trait for `CanRaiseError<E>`.
- Add `cgp-error-eyre` crate for providing generic error handling using `eyre`.
- Add `cgp-error-std` crate or providing generic error handling using `Box<dyn std::error::Error>`.