### PR TITLE
Use marker trait pattern to simplify component delegation

### DIFF
--- a/crates/cgp-component/src/macros/delegate_all.rs
+++ b/crates/cgp-component/src/macros/delegate_all.rs
@@ -1,0 +1,16 @@
+#[macro_export]
+macro_rules! delegate_all {
+    (
+        $source_marker:ident,
+        $source:ty,
+        $target:ty
+            $(,)?
+    ) => {
+        impl<Component> DelegateComponent<Component> for $target
+        where
+            Self: $source_marker<Component>,
+        {
+            type Delegate = $source;
+        }
+    };
+}

--- a/crates/cgp-component/src/macros/delegate_component.rs
+++ b/crates/cgp-component/src/macros/delegate_component.rs
@@ -3,8 +3,9 @@ macro_rules! delegate_component {
     (
         $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-        ;
-        $name:ty : $forwarded:ty $(,)?
+        {
+            $name:ty : $forwarded:ty $(,)?
+        }
     ) => {
         impl< $( $( $param ),* )* >
             $crate::traits::delegate_component::DelegateComponent< $name >

--- a/crates/cgp-component/src/macros/delegate_component.rs
+++ b/crates/cgp-component/src/macros/delegate_component.rs
@@ -3,7 +3,6 @@ macro_rules! delegate_component {
     (
         $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            $( @markers[ $( $marker:ident ),* $(,)? ] )?
         ;
         $name:ty : $forwarded:ty $(,)?
     ) => {
@@ -15,11 +14,5 @@ macro_rules! delegate_component {
         {
             type Delegate = $forwarded;
         }
-
-        $(
-            $crate::impl_component_marker!(
-                $name : [ $( $marker ),* ]
-            );
-        )?
     };
 }

--- a/crates/cgp-component/src/macros/delegate_component.rs
+++ b/crates/cgp-component/src/macros/delegate_component.rs
@@ -1,6 +1,10 @@
 #[macro_export]
 macro_rules! delegate_component {
-    ( $target:ident $( < $( $param:ident ),* $(,)? > )?;
+    (
+        $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+            $( @markers[ $( $marker:ident ),* $(,)? ] )?
+        ;
         $name:ty : $forwarded:ty $(,)?
     ) => {
         impl< $( $( $param ),* )* >
@@ -11,5 +15,11 @@ macro_rules! delegate_component {
         {
             type Delegate = $forwarded;
         }
+
+        $(
+            $crate::impl_component_marker!(
+                $name : [ $( $marker ),* ]
+            );
+        )?
     };
 }

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -1,8 +1,8 @@
 #[macro_export]
 macro_rules! delegate_components {
     (
-        @mark_component( $marker:ident )
-        @mark_delegate( $delegate_marker:ident )
+        #[mark_component( $marker:ident )]
+        #[mark_delegate( $delegate_marker:ident )]
         $target:ident
             $( < $( $param:ident ),* $(,)? > )?
             ;
@@ -39,10 +39,9 @@ macro_rules! delegate_components {
                 {}
             )
         );
-
     };
     (
-        $( @mark_component( $marker:ident ) )?
+        $( #[mark_component( $marker:ident )] )?
         $target:ident
             $( < $( $param:ident ),* $(,)? > )?
             ;
@@ -52,6 +51,18 @@ macro_rules! delegate_components {
             pub trait $marker < Component > {}
         )?
 
+        $crate::delegate_components!(
+            $( @mark_component( $marker ) )?
+            @target( $target $( < $( $param ),* > )? )
+            @body( $( $rest )* )
+        );
+    };
+    (
+        $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+            ;
+        $( $rest:tt )*
+    ) => {
         $crate::delegate_components!(
             $( @mark_component( $marker ) )?
             @target( $target $( < $( $param ),* > )? )

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -7,6 +7,10 @@ macro_rules! delegate_components {
             ;
         $( $rest:tt )*
     ) => {
+        $(
+            pub trait $marker < Component > {}
+        )?
+
         $crate::delegate_components!(
             $( @marker( $marker ) )?
             @target( $target $( < $( $param ),* > )? )

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -1,43 +1,71 @@
 #[macro_export]
 macro_rules! delegate_components {
-    ( $target:ident $( < $( $param:ident ),* $(,)? > )? ; ) => {
+    (   $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+            $( @markers[ $( $marker:ident ),* $(,)? ] )?
+            ;
+    ) => {
 
     };
-    (   $target:ident $( < $( $param:ident ),* $(,)? > )?;
+    (   $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+            $( @markers[ $( $marker:ident ),* $(,)? ] )?
+            ;
         [ ] : $forwarded:ty
         $( , $( $rest:tt )* )?
     ) => {
         $crate::delegate_components!(
-            $target $( < $( $param ),* > )* ;
+            $target
+                $( < $( $param ),* > )*
+                $( @markers[ $( $marker ),* ] )?
+                ;
             $( $( $rest )*  )?
         );
     };
-    ( $target:ident $( < $( $param:ident ),* $(,)? > )? ;
+    (   $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+            $( @markers[ $( $marker:ident ),* $(,)? ] )?
+            ;
         [ $name:ty $(, $($names:tt)* )?] : $forwarded:ty
         $( , $( $rest:tt )* )?
     ) => {
         $crate::delegate_component!(
-            $target $( < $( $param ),* > )*;
+            $target
+                $( < $( $param ),* > )*
+                $( @markers[ $( $marker ),* ] )?
+                ;
             $name : $forwarded
         );
 
         $crate::delegate_components!(
-            $target $( < $( $param ),* > )* ;
+            $target
+                $( < $( $param ),* > )*
+                $( @markers[ $( $marker ),* ] )?
+                ;
             [ $( $( $names )* )? ] : $forwarded
             $( , $( $rest )*  )?
         );
     };
-    (   $target:ident $( < $( $param:ident ),* $(,)? > )? ;
+    (   $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+            $( @markers[ $( $marker:ident ),* $(,)? ] )?
+            ;
         $name:ty : $forwarded:ty
         $( , $( $rest:tt )* )?
     ) => {
         $crate::delegate_component!(
-            $target $( < $( $param ),* > )*;
+            $target
+                $( < $( $param ),* > )*
+                $( @markers[ $( $marker ),* ] )?
+                ;
             $name : $forwarded
         );
 
         $crate::delegate_components!(
-            $target $( < $( $param ),* > )* ;
+            $target
+                $( < $( $param ),* > )*
+                $( @markers[ $( $marker ),* ] )?
+                ;
             $( $( $rest )*  )?
         );
     };

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -5,8 +5,9 @@ macro_rules! delegate_components {
         #[mark_delegate( $delegate_marker:ident )]
         $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            ;
-        $( $rest:tt )*
+        {
+            $( $rest:tt )*
+        }
     ) => {
         $crate::delegate_components!(
             @mark_component( $marker )
@@ -133,8 +134,9 @@ macro_rules! delegate_components {
         $crate::delegate_component!(
             $target
                 $( < $( $param ),* > )*
-                ;
-            $name : $forwarded
+            {
+                $name : $forwarded
+            }
         );
 
         $( impl<T> $marker < $name > for T {} )?

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -45,25 +45,14 @@ macro_rules! delegate_components {
         $( #[mark_component( $marker:ident )] )?
         $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            ;
-        $( $rest:tt )*
+        {
+            $( $rest:tt )*
+        }
     ) => {
         $(
             pub trait $marker < Component > {}
         )?
 
-        $crate::delegate_components!(
-            $( @mark_component( $marker ) )?
-            @target( $target $( < $( $param ),* > )? )
-            @body( $( $rest )* )
-        );
-    };
-    (
-        $target:ident
-            $( < $( $param:ident ),* $(,)? > )?
-            ;
-        $( $rest:tt )*
-    ) => {
         $crate::delegate_components!(
             $( @mark_component( $marker ) )?
             @target( $target $( < $( $param ),* > )? )

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -20,7 +20,7 @@ macro_rules! delegate_components {
             @target( $target $( < $( $param ),* > )? )
             @body( $( $rest )* )
             @head_buf(
-                pub trait $delegate_marker: Sized
+                pub trait $delegate_marker $( < $( $param ),* > )? : Sized
             )
             @tail_buf(
                 {}
@@ -31,7 +31,7 @@ macro_rules! delegate_components {
             @target( $target $( < $( $param ),* > )? )
             @body( $( $rest )* )
             @head_buf(
-                impl<Components> $delegate_marker for Components
+                impl<Components, $( $( $param ),* )? > $delegate_marker $( < $( $param ),* > )? for Components
                 where
                     Components: Sized
             )

--- a/crates/cgp-component/src/macros/delegate_components.rs
+++ b/crates/cgp-component/src/macros/delegate_components.rs
@@ -1,72 +1,102 @@
 #[macro_export]
 macro_rules! delegate_components {
-    (   $target:ident
+    (
+        $( @marker( $marker:ident ) )?
+        $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            $( @markers[ $( $marker:ident ),* $(,)? ] )?
             ;
+        $( $rest:tt )*
+    ) => {
+        $crate::delegate_components!(
+            $( @marker( $marker ) )?
+            @target( $target $( < $( $param ),* > )? )
+            @body( $( $rest )* )
+        );
+    };
+    (
+        $( @marker( $marker:ident ) )?
+        @target(
+            $target:ident
+            $( < $( $param:ident ),* $(,)? > )?
+        )
+        @body(  )
     ) => {
 
     };
-    (   $target:ident
+    (
+        $( @marker( $marker:ident ) )?
+        @target(
+            $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            $( @markers[ $( $marker:ident ),* $(,)? ] )?
-            ;
-        [ ] : $forwarded:ty
-        $( , $( $rest:tt )* )?
+        )
+        @body(
+            [ ] : $forwarded:ty
+            $( , $( $rest:tt )* )?
+        )
     ) => {
         $crate::delegate_components!(
-            $target
-                $( < $( $param ),* > )*
-                $( @markers[ $( $marker ),* ] )?
-                ;
-            $( $( $rest )*  )?
+            $( @marker( $marker ) )?
+            @target( $target $( < $( $param ),* > )? )
+            @body(
+                $( $( $rest )*  )?
+            )
         );
     };
-    (   $target:ident
+    (
+        $( @marker( $marker:ident ) )?
+        @target(
+            $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            $( @markers[ $( $marker:ident ),* $(,)? ] )?
-            ;
-        [ $name:ty $(, $($names:tt)* )?] : $forwarded:ty
-        $( , $( $rest:tt )* )?
+        )
+        @body(
+            [ $name:ty $(, $($names:tt)* )?] : $forwarded:ty
+            $( , $( $rest:tt )* )?
+        )
     ) => {
         $crate::delegate_component!(
             $target
                 $( < $( $param ),* > )*
-                $( @markers[ $( $marker ),* ] )?
                 ;
             $name : $forwarded
         );
 
+        $( impl<T> $marker < $name > for T {} )?
+
         $crate::delegate_components!(
-            $target
-                $( < $( $param ),* > )*
-                $( @markers[ $( $marker ),* ] )?
-                ;
-            [ $( $( $names )* )? ] : $forwarded
-            $( , $( $rest )*  )?
+            $( @marker( $marker ) )?
+            @target( $target $( < $( $param ),* > )? )
+            @body(
+                [ $( $( $names )* )? ] : $forwarded
+                $( , $( $rest )*  )?
+            )
         );
     };
-    (   $target:ident
+    (
+        $( @marker( $marker:ident ) )?
+        @target(
+            $target:ident
             $( < $( $param:ident ),* $(,)? > )?
-            $( @markers[ $( $marker:ident ),* $(,)? ] )?
-            ;
-        $name:ty : $forwarded:ty
-        $( , $( $rest:tt )* )?
+        )
+        @body(
+            $name:ty : $forwarded:ty
+            $( , $( $rest:tt )* )?
+        )
     ) => {
         $crate::delegate_component!(
             $target
                 $( < $( $param ),* > )*
-                $( @markers[ $( $marker ),* ] )?
                 ;
             $name : $forwarded
         );
 
+        $( impl<T> $marker < $name > for T {} )?
+
         $crate::delegate_components!(
-            $target
-                $( < $( $param ),* > )*
-                $( @markers[ $( $marker ),* ] )?
-                ;
-            $( $( $rest )*  )?
+            $( @marker( $marker ) )?
+            @target( $target $( < $( $param ),* > )? )
+            @body(
+                $( $( $rest )*  )?
+            )
         );
     };
 }

--- a/crates/cgp-component/src/macros/expand_delegate_constraints.rs
+++ b/crates/cgp-component/src/macros/expand_delegate_constraints.rs
@@ -43,7 +43,7 @@ macro_rules! expand_delegate_constraints {
                 [ $( $( $names )* )? ] : $forwarded,
                 $( $( $rest )*  )?
             )
-            @head_buf( $( $head:tt )* )
+            @head_buf( $( $head )* )
             @tail_buf( $( $tail )* )
         );
     };

--- a/crates/cgp-component/src/macros/expand_delegate_constraints.rs
+++ b/crates/cgp-component/src/macros/expand_delegate_constraints.rs
@@ -1,0 +1,71 @@
+#[macro_export]
+macro_rules! expand_delegate_constraints {
+    (
+        @target( $target:ty )
+        @body(  )
+        @head_buf( $( $head:tt )* )
+        @tail_buf( $( $tail:tt )* )
+    ) => {
+        $( $head )*
+        $( $tail )*
+    };
+    (
+        @target( $target:ty )
+        @body(
+            [ ] : $forwarded:ty
+            $( , $( $rest:tt )* )?
+        )
+        @head_buf( $( $head:tt )* )
+        @tail_buf( $( $tail:tt )* )
+    ) => {
+        $crate::expand_delegate_constraints!(
+            @target( $target )
+            @body(
+                $( $( $rest )*  )?
+            )
+            @head_buf( $( $head )* )
+            @tail_buf( $( $tail )* )
+        );
+    };
+    (
+        @target( $target:ty )
+        @body(
+            [ $name:ty $(, $($names:tt)* )?] : $forwarded:ty
+            $( , $( $rest:tt )* )?
+        )
+        @head_buf( $( $head:tt )* )
+        @tail_buf( $( $tail:tt )* )
+    ) => {
+        $crate::expand_delegate_constraints!(
+            @target( $target )
+            @body(
+                $name : $forwarded,
+                [ $( $( $names )* )? ] : $forwarded,
+                $( $( $rest )*  )?
+            )
+            @head_buf( $( $head:tt )* )
+            @tail_buf( $( $tail )* )
+        );
+    };
+    (
+        @target( $target:ty )
+        @body(
+            $name:ty : $forwarded:ty
+            $( , $( $rest:tt )* )?
+        )
+        @head_buf( $( $head:tt )* )
+        @tail_buf( $( $tail:tt )* )
+    ) => {
+        $crate::expand_delegate_constraints!(
+            @target( $target )
+            @body(
+                $( $( $rest )*  )?
+            )
+            @head_buf(
+                $( $head )*
+                + $crate::traits::delegate_component::DelegateComponent< $name, Delegate = $target >
+            )
+            @tail_buf( $( $tail )* )
+        );
+    };
+}

--- a/crates/cgp-component/src/macros/impl_component_marker.rs
+++ b/crates/cgp-component/src/macros/impl_component_marker.rs
@@ -1,0 +1,9 @@
+#[macro_export]
+macro_rules! impl_component_marker {
+    ( $name:ty: [ $( $marker_trait:ident ),* $(,)? ]
+    ) => {
+        $(
+            impl<T> $marker_trait< $name > for T {}
+        )*
+    };
+}

--- a/crates/cgp-component/src/macros/impl_component_marker.rs
+++ b/crates/cgp-component/src/macros/impl_component_marker.rs
@@ -1,9 +1,0 @@
-#[macro_export]
-macro_rules! impl_component_marker {
-    ( $name:ty: [ $( $marker_trait:ident ),* $(,)? ]
-    ) => {
-        $(
-            impl<T> $marker_trait< $name > for T {}
-        )*
-    };
-}

--- a/crates/cgp-component/src/macros/mod.rs
+++ b/crates/cgp-component/src/macros/mod.rs
@@ -1,3 +1,4 @@
+pub mod delegate_all;
 pub mod delegate_component;
 pub mod delegate_components;
 pub mod expand_delegate_constraints;

--- a/crates/cgp-component/src/macros/mod.rs
+++ b/crates/cgp-component/src/macros/mod.rs
@@ -1,3 +1,2 @@
 pub mod delegate_component;
 pub mod delegate_components;
-pub mod impl_component_marker;

--- a/crates/cgp-component/src/macros/mod.rs
+++ b/crates/cgp-component/src/macros/mod.rs
@@ -1,2 +1,3 @@
 pub mod delegate_component;
 pub mod delegate_components;
+pub mod impl_component_marker;

--- a/crates/cgp-component/src/macros/mod.rs
+++ b/crates/cgp-component/src/macros/mod.rs
@@ -1,2 +1,3 @@
 pub mod delegate_component;
 pub mod delegate_components;
+pub mod expand_delegate_constraints;

--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -3,7 +3,8 @@
 pub mod prelude;
 
 pub use cgp_component::{
-    delegate_component, delegate_components, derive_component, DelegateComponent, HasComponents,
+    delegate_all, delegate_component, delegate_components, derive_component, DelegateComponent,
+    HasComponents,
 };
 
 pub use cgp_async::{async_trait, Async};


### PR DESCRIPTION
This PR introduces a number of breaking changes to make delegation of group of components simpler.

### New syntax for `delegate_components`

Old syntax:

```rust
delegate_components!(
    MyComponents;
    FooComponent: FooImpl,
    BarComponent: BarImpl,
);
```

New syntax:

```rust
delegate_components! {
    MyComponents {
        FooComponent: FooImpl,
        BarComponent: BarImpl,
    }
}
```

### Component Marker Trait

A component marker trait is used to mark whether a component can be delegated to a component graph. The `#[mark_component(MarkerName)]` syntax can be used to create a component trait for a specific component graph.

For example, the following code:

```rust
delegate_components! {
    #[mark_component(IsMyComponent)]
    MyComponents {
        FooComponent: FooImpl,
        BarComponent: BarImpl,
    }
}
```

would be desugared to contain the marker trait definition:

```rust
pub trait IsMyComponent<Component> {}

impl<T> IsMyComponent<FooComponent> for T {}
impl<T> IsMyComponent<BarComponent> for T {}
```

### Delegate All

The marker trait can be used for auto component delegation using the new `delegate_all!` macro.

For example, with the following code:

```rust
pub struct MyExtendedComponents;

delegate_components! {
    MyExtendedComponents {
        BarComponent: BarImpl,
    }
}

delegate_all!(
    IsMyComponent,
    MyComponents,
    MyExtendedComponents,
);
```

The call to `delegate_all!` would be expanded into the following blanket implementation:

```rust
impl<Component> DelegateComponent<Component> for MyExtendedComponents 
where
    Self: IsMyComponent<Component>,
{
    type Delegate = MyComponents;
}
```

In this way, `MyExtendedComponents` would automatically delegate both `FooComponent` and `BarComponent` to `MyComponents` without having explicitly list out the components.

It is worth noting that the blanket implementation of `DelegateComponent` can only be done once. So it is not possible to use `delegate_all!` multiple times to delegate to multiple non-overlapping component graphs.

The additional use of `Self: IsMyComponent<Component>` instead of `Component: IsMyComponent` is necessary to workaround the limitation that Rust places on conflicting trait implementation.

Consider the alternative naive implementation of the desugared code:

```rust
// crate `my_components`
pub trait NaiveIsMyComponent {}

impl NaiveIsMyComponent for FooComponent {}
impl NaiveIsMyComponent for BarComponent {}
```

If we use `NaiveIsMyComponent` in a separate crate as follows:

```rust
// crate `my_extended_components`
impl<Component> DelegateComponent<Component> for MyExtendedComponents 
where
    Component: IsMyComponent,
{
    type Delegate = MyComponents;
}
```

We would get a compile error saying `conflicting implementations of trait [...] note: upstream crates may add a new impl of trait in future versions`.

The conflict is because the crate for `my_extended_components` does not own both the `NaiveIsMyComponent` trait, and the generic `Component` type that is used as `Self` in `MyComponents`. As described in https://github.com/rust-lang/rfcs/issues/2758, this is an artificial limitation placed by Rust to ensure that adding new trait implementation to a `Self` type will not introduce breaking changes to downstream crates.

We found a workaround in this PR, which is that the limitation can be lifted as long as the crate owns the `Self` type. What we need is for the provider of the marker trait to provide a blanket implementation of all possible self types:

```rust
impl<T> IsMyComponent<FooComponent> for T {}
```

This way, when we use the constraint `Self: IsMyComponent<Component>`, Rust becomes happy to accept the constraint and no longer prevent future breaking changes. We can verify that the original limitation still exists if we change `Self` to other types that the crate do not own, such as `(): IsMyComponent<Component>`.

### Delegation Marker Trait

As a complement to `delegate_all!`, the `#[mark_delegate(DelegateMarker)]` syntax can be used to auto implement a marker trait that indicates that another component graph has delegated all component to the target component graph.

For example, the following code:

```rust
delegate_components! {
    #[mark_component(IsMyComponent)]
    #[mark_delegate(DelegatesToMyComponents)]
    MyComponents {
        FooComponent: FooImpl,
        BarComponent: BarImpl,
    }
}
```

would include the following code expansion:

```rust
pub trait DelegatesToMyComponents: 
    DelegateComponent<FooComponent, Component = MyComponents>
    + DelegateComponent<BarComponent, Component = MyComponents>
{}

impl<Components> DelegatesToMyComponents for Components
where
    Components: 
        DelegateComponent<FooComponent, Component = MyComponents>
        + DelegateComponent<BarComponent, Component = MyComponents>
{}
```

The trait `DelegatesToMyComponents` would automatically be implemented by other component graphs that use `delegate_all!` with `MyComponents`, such as `MyExtendedComponents`.

The delegation marker trait can be used to reason about the property of generic contexts that make use of a specific component graph. For example, we can construct a constraint closure around any context with component graph that delegates to `MyComponents`.

### Further Details

Further details will be written, once I have the time to write down the detailed documentation for context-generic programming.