### PR TITLE
Fix use of GAT with trait bounds inside `derive_component!` macro

### DIFF
--- a/crates/cgp-component-macro/src/helper/consumer_impl.rs
+++ b/crates/cgp-component-macro/src/helper/consumer_impl.rs
@@ -1,6 +1,9 @@
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, For, Impl, Plus};
-use syn::{parse_quote, Ident, ImplItem, ItemImpl, ItemTrait, Path, TraitItem, TypeParamBound};
+use syn::{
+    parse_quote, GenericParam, Ident, ImplItem, ItemImpl, ItemTrait, Path, TraitItem,
+    TypeParamBound,
+};
 
 use crate::helper::delegate_fn::derive_delegated_fn_impl;
 use crate::helper::delegate_type::derive_delegate_type_impl;
@@ -89,6 +92,13 @@ pub fn derive_consumer_impl(
                 let type_generics = {
                     let mut type_generics = trait_type.generics.clone();
                     type_generics.where_clause = None;
+
+                    for param in &mut type_generics.params {
+                        if let GenericParam::Type(type_param) = param {
+                            type_param.bounds.clear();
+                        }
+                    }
+
                     type_generics
                 };
 

--- a/crates/cgp-component-macro/src/helper/provider_impl.rs
+++ b/crates/cgp-component-macro/src/helper/provider_impl.rs
@@ -1,7 +1,10 @@
 use proc_macro2::Span;
 use syn::punctuated::Punctuated;
 use syn::token::{Brace, Comma, For, Impl, Plus};
-use syn::{parse_quote, Ident, ImplItem, ItemImpl, ItemTrait, Path, TraitItem, TypeParamBound};
+use syn::{
+    parse_quote, GenericParam, Ident, ImplItem, ItemImpl, ItemTrait, Path, TraitItem,
+    TypeParamBound,
+};
 
 use crate::helper::delegate_fn::derive_delegated_fn_impl;
 use crate::helper::delegate_type::derive_delegate_type_impl;
@@ -74,6 +77,13 @@ pub fn derive_provider_impl(
                 let type_generics = {
                     let mut type_generics = trait_type.generics.clone();
                     type_generics.where_clause = None;
+
+                    for param in &mut type_generics.params {
+                        if let GenericParam::Type(type_param) = param {
+                            type_param.bounds.clear();
+                        }
+                    }
+
                     type_generics
                 };
 


### PR DESCRIPTION
Fix a macro expansion issue that the trait bound of generic associated types are propagated to the use site inside the generated `impl` blocks.