### PR TITLE
Add separate error raisers for eyre handler

### DIFF
--- a/crates/cgp-core/src/lib.rs
+++ b/crates/cgp-core/src/lib.rs
@@ -2,18 +2,14 @@
 
 pub mod prelude;
 
+pub use cgp_async::{async_trait, Async};
 pub use cgp_component::{
     delegate_all, delegate_component, delegate_components, derive_component, DelegateComponent,
     HasComponents,
 };
-
-pub use cgp_async::{async_trait, Async};
-
 pub use cgp_error::{
     CanRaiseError, ErrorRaiser, ErrorRaiserComponent, ErrorTypeComponent, HasErrorType,
     ProvideErrorType,
 };
-
-pub use cgp_run::{CanRun, Runner, RunnerComponent};
-
 pub use cgp_inner::{HasInner, InnerComponent, ProvideInner};
+pub use cgp_run::{CanRun, Runner, RunnerComponent};

--- a/crates/cgp-core/src/prelude.rs
+++ b/crates/cgp-core/src/prelude.rs
@@ -1,5 +1,3 @@
-pub use cgp_component::{delegate_components, derive_component, DelegateComponent, HasComponents};
-
 pub use cgp_async::{async_trait, Async};
-
+pub use cgp_component::{delegate_components, derive_component, DelegateComponent, HasComponents};
 pub use cgp_error::HasErrorType;

--- a/crates/cgp-error-eyre/src/lib.rs
+++ b/crates/cgp-error-eyre/src/lib.rs
@@ -1,10 +1,9 @@
-use cgp_core::prelude::*;
-use cgp_core::ErrorRaiser;
-use cgp_core::ProvideErrorType;
-use core::fmt::Debug;
-use core::fmt::Display;
-use eyre::{eyre, Report};
+use core::fmt::{Debug, Display};
 use std::error::Error as StdError;
+
+use cgp_core::prelude::*;
+use cgp_core::{ErrorRaiser, ProvideErrorType};
+use eyre::{eyre, Report};
 
 pub struct ProvideEyreError;
 

--- a/crates/cgp-error-eyre/src/lib.rs
+++ b/crates/cgp-error-eyre/src/lib.rs
@@ -1,24 +1,52 @@
 use cgp_core::prelude::*;
 use cgp_core::ErrorRaiser;
 use cgp_core::ProvideErrorType;
-use eyre::Report;
+use core::fmt::Debug;
+use core::fmt::Display;
+use eyre::{eyre, Report};
 use std::error::Error as StdError;
 
-pub struct HandleErrorsWithEyre;
+pub struct ProvideEyreError;
 
-impl<Context> ProvideErrorType<Context> for HandleErrorsWithEyre
+impl<Context> ProvideErrorType<Context> for ProvideEyreError
 where
     Context: Async,
 {
     type Error = Report;
 }
 
-impl<Context, E> ErrorRaiser<Context, E> for HandleErrorsWithEyre
+pub struct RaiseStdError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseStdError
 where
     Context: HasErrorType<Error = Report>,
     E: StdError + Async,
 {
     fn raise_error(e: E) -> Report {
         e.into()
+    }
+}
+
+pub struct RaiseDebugError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseDebugError
+where
+    Context: HasErrorType<Error = Report>,
+    E: Debug,
+{
+    fn raise_error(e: E) -> Report {
+        eyre!("{:?}", e)
+    }
+}
+
+pub struct RaiseDisplayError;
+
+impl<Context, E> ErrorRaiser<Context, E> for RaiseDisplayError
+where
+    Context: HasErrorType<Error = Report>,
+    E: Display,
+{
+    fn raise_error(e: E) -> Report {
+        eyre!("{e}")
     }
 }

--- a/crates/cgp-error-std/src/lib.rs
+++ b/crates/cgp-error-std/src/lib.rs
@@ -1,7 +1,7 @@
-use cgp_core::prelude::*;
-use cgp_core::ErrorRaiser;
-use cgp_core::ProvideErrorType;
 use std::error::Error as StdError;
+
+use cgp_core::prelude::*;
+use cgp_core::{ErrorRaiser, ProvideErrorType};
 
 pub type Error = Box<dyn StdError + Send + Sync + 'static>;
 


### PR DESCRIPTION

- The `ProvideEyreError` component implements `HasErrorType::Error` with `eyre::Report`.
- The `RaiseStdError` provides generic `CanRaiseError<E>` for any `E: std::error::Error` by wrapping it into `eyre::Report`.
- The `RaiseDebugError` provides generic `CanRaiseError<E>` for any `E: Debug` by wrapping it into `eyre::Report`.
- The `RaiseDisplayError` provides generic `CanRaiseError<E>` for any `E: Display` by wrapping it into `eyre::Report`.